### PR TITLE
sanity check on all models

### DIFF
--- a/tests/test_payload_subscribe.py
+++ b/tests/test_payload_subscribe.py
@@ -14,7 +14,7 @@ import xumm
 import asyncio
 
 import pytest
-# @pytest.mark.skip(reason="Using Prod Cert")
+@pytest.mark.skip(reason="Using Prod Cert")
 class TestPayloadSubscribe(BaseTestConfig):
 
     @classmethod

--- a/xumm/resource/__init__.py
+++ b/xumm/resource/__init__.py
@@ -26,23 +26,34 @@ class PrintableResource(object):
     def sanity_check(cls, kwargs):
         """Runs a sanity check on the model"""
 
-        for attr, is_type in six.iteritems(cls.model_types):
+        for _attr, is_type in six.iteritems(cls.model_types):
+
+            # Use the attribute map for RECEIVING json data (Camelcase)
+            attr = cls.attribute_map[_attr]
+            
+            # Error if attribute not in json and attribute in required
             if attr not in kwargs and attr in cls.required:
                 raise ValueError("Invalid value for `{}`, must not be `None`".format(attr))
 
-            if attr not in kwargs and attr in cls.nullable:
+            # Skip option attributes if non exists in json
+            if attr not in kwargs and attr not in cls.required:
                 continue
             
+            # set value for attribute
             value = kwargs[attr]
 
-            if attr in cls.nullable and value == {} or value == None:
+            # Skip nullable attributes if empty json, list or None
+            if attr in cls.nullable and value == {} or value == [] or value == None or value == '':
                 continue
                 
 
-            # validate type if required
+            # Error if value is instance of attribute type
+            print(value)
+            print(is_type)
             if not isinstance(value, is_type):
                 raise ValueError("Invalid value for `{}`, must be a `{}`".format(attr, is_type))
 
+            # Error if attribute is required and value is None: 2x of ^^^ Prod Delete in final
             if attr in cls.required and value is None:
                 raise ValueError("Invalid value for `{}`, must not be `None`".format(attr))
 

--- a/xumm/resource/types/meta/any_json.py
+++ b/xumm/resource/types/meta/any_json.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python
-# coding: utf-8
-
-from typing import Dict, Any
-
-# export type AnyJson = Record<string, any>
-
-
-any_json: Dict[str, Any]

--- a/xumm/resource/types/meta/application_details.py
+++ b/xumm/resource/types/meta/application_details.py
@@ -8,8 +8,12 @@ from typing import Union, List, Dict, Callable, Any  # noqa: F401
 
 class Call(XummResource):
 
+    required = {
+        'uuidv4': True
+    }
+
     model_types = {
-        'uuidv4': 'str'
+        'uuidv4': str
     }
 
     attribute_map = {
@@ -24,6 +28,7 @@ class Call(XummResource):
         :return: The Call of this Call.  # noqa: E501
         :rtype: Call
         """
+        cls.sanity_check(kwargs)
         cls._uuidv4 = None
         cls.uuidv4 = kwargs['uuidv4']
 
@@ -80,11 +85,18 @@ class Call(XummResource):
 
 class Application(XummResource):
 
+    required = {
+        'name': True,
+        'uuidv4': True,
+        'webhookurl': True,
+        'disabled': True
+    }
+
     model_types = {
-        'name': 'str',
-        'uuidv4': 'str',
-        'webhookurl': 'str',
-        'disabled': 'int'
+        'name': str,
+        'uuidv4': str,
+        'webhookurl': str,
+        'disabled': int
     }
 
     attribute_map = {
@@ -102,7 +114,7 @@ class Application(XummResource):
         :return: The Application of this Application.  # noqa: E501
         :rtype: Application
         """
-        # cls.sanity_check(kwargs)
+        cls.sanity_check(kwargs)
         cls._name = None
         cls._uuidv4 = None
         cls._webhookurl = None
@@ -116,7 +128,7 @@ class Application(XummResource):
         """Returns the model properties as a dict"""
         result = {}
 
-        for attr, _ in six.iteritems(cls.model_types):
+        for attr, _ in six.iteritems(cls.attribute_map):
             value = getattr(cls, attr)
             attr = cls.attribute_map[attr]
             if isinstance(value, list):
@@ -273,7 +285,7 @@ class Application(XummResource):
 class Quota(XummResource):
 
     model_types = {
-        'ratelimit': 'str'
+        'ratelimit': str
     }
 
     attribute_map = {
@@ -288,6 +300,7 @@ class Quota(XummResource):
         :return: The Quota of this Quota.  # noqa: E501
         :rtype: Quota
         """
+        cls.sanity_check(kwargs)
         cls._ratelimit = None
         if 'ratelimit' in kwargs:
             cls.ratelimit = kwargs['ratelimit']
@@ -346,10 +359,16 @@ class Quota(XummResource):
 
 class ApplicationDetails(XummResource):
 
+    required = {
+        'quota': True,
+        'application': True,
+        'call': True
+    }
+
     model_types = {
-        'quota': 'Quota',
-        'application': 'Application',
-        'call': 'Call'
+        'quota': dict,
+        'application': dict,
+        'call': dict
     }
 
     attribute_map = {
@@ -366,6 +385,7 @@ class ApplicationDetails(XummResource):
         :return: The PongResponse of this PongResponse.  # noqa: E501
         :rtype: PongResponse
         """
+        cls.sanity_check(kwargs)
         cls._quota = None
         cls._application = None
         cls._call = None
@@ -377,7 +397,7 @@ class ApplicationDetails(XummResource):
         """Returns the model properties as a dict"""
         result = {}
 
-        for attr, _ in six.iteritems(cls.model_types):
+        for attr, _ in six.iteritems(cls.attribute_map):
             value = getattr(cls, attr)
             attr = cls.attribute_map[attr]
             if isinstance(value, list):

--- a/xumm/resource/types/meta/curated_assets_response.py
+++ b/xumm/resource/types/meta/curated_assets_response.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8
 
+from urllib import request
 from xumm.resource import XummResource
 import six
 from typing import Union, List, Dict, Callable, Any  # noqa: F401
@@ -8,16 +9,27 @@ from typing import Union, List, Dict, Callable, Any  # noqa: F401
 
 class Currency(XummResource):
 
-    model_types = {
-        'id': 'int',
-        'issuer_id': 'int',
-        'issuer': 'str',
-        'currency': 'str',
-        'name': 'str',
-        'avatar': 'str',
-        'shortlist': 'int'
+    required = {
+        'id': True,
+        'issuer_id': True,
+        'issuer': True,
+        'currency': True,
+        'name': True,
+        'avatar': True,
+        'shortlist': True
     }
-    attribute_list = {
+
+    model_types = {
+        'id': int,
+        'issuer_id': int,
+        'issuer': str,
+        'currency': str,
+        'name': str,
+        'avatar': str,
+        'shortlist': int
+    }
+
+    attribute_map = {
         'id': 'id',
         'issuer_id': 'issuer_id',
         'issuer': 'issuer',
@@ -35,6 +47,7 @@ class Currency(XummResource):
         :return: The Currency of this Currency.  # noqa: E501
         :rtype: Currency
         """
+        cls.sanity_check(kwargs)
         cls._id = None
         cls._issuer_id = None
         cls._issuer = None
@@ -54,9 +67,9 @@ class Currency(XummResource):
         """Returns the model properties as a dict"""
         result = {}
 
-        for attr, _ in six.iteritems(cls.model_types):
+        for attr, _ in six.iteritems(cls.attribute_map):
             value = getattr(cls, attr)
-            attr = cls.attribute_list[attr]
+            attr = cls.attribute_map[attr]
             if isinstance(value, list):
                 result[attr] = list(map(
                     lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
@@ -238,15 +251,25 @@ class Currency(XummResource):
 
 class Asset(XummResource):
 
-    model_types = {
-        'id': 'int',
-        'name': 'str',
-        'domain': 'str',
-        'avatar': 'str',
-        'shortlist': 'int',
-        'currencies': 'dict(str, Currency)'
+    required = {
+        'id': True,
+        'name': True,
+        'domain': True,
+        'avatar': True,
+        'shortlist': True,
+        'currencies': True
     }
-    attribute_list = {
+
+    model_types = {
+        'id': int,
+        'name': str,
+        'domain': str,
+        'avatar': str,
+        'shortlist': int,
+        'currencies': dict
+    }
+
+    attribute_map = {
         'id': 'id',
         'name': 'name',
         'domain': 'domain',
@@ -263,6 +286,7 @@ class Asset(XummResource):
         :return: The Asset of this Asset.  # noqa: E501
         :rtype: Asset
         """
+        cls.sanity_check(kwargs)
         cls._id = None
         cls._name = None
         cls._domain = None
@@ -280,10 +304,10 @@ class Asset(XummResource):
         """Returns the model properties as a dict"""
         result = {}
 
-        for attr, _ in six.iteritems(cls.model_types):
+        for attr, _ in six.iteritems(cls.attribute_map):
             value = getattr(cls, attr)
             print(attr)
-            attr = cls.attribute_list[attr]
+            attr = cls.attribute_map[attr]
             if isinstance(value, list):
                 result[attr] = list(map(
                     lambda x: x.to_dict() if hasattr(x, "to_dict") else x,

--- a/xumm/resource/types/meta/kyc_info_response.py
+++ b/xumm/resource/types/meta/kyc_info_response.py
@@ -8,9 +8,14 @@ from typing import Union, List, Dict, Callable, Any  # noqa: F401
 
 class KycInfoResponse(XummResource):
 
+    required = {
+        'account': True,
+        'kyc_approved': True,
+    }
+
     model_types = {
-        'account': 'str',
-        'kyc_approved': 'bool'
+        'account': str,
+        'kyc_approved': bool
     }
 
     attribute_map = {
@@ -26,7 +31,7 @@ class KycInfoResponse(XummResource):
         :return: The KycInfoResponse of this KycInfoResponse.  # noqa: E501
         :rtype: KycInfoResponse
         """
-        # print(json.dumps(kwargs, indent=4, sort_keys=True))
+        cls.sanity_check(kwargs)
         cls._account = None
         cls._kyc_approved = None
         cls.account = kwargs['account']
@@ -36,7 +41,7 @@ class KycInfoResponse(XummResource):
         """Returns the model properties as a dict"""
         result = {}
 
-        for attr, _ in six.iteritems(cls.model_types):
+        for attr, _ in six.iteritems(cls.attribute_map):
             value = getattr(cls, attr)
             attr = cls.attribute_map[attr]
             if isinstance(value, list):

--- a/xumm/resource/types/meta/kyc_status_response.py
+++ b/xumm/resource/types/meta/kyc_status_response.py
@@ -8,9 +8,14 @@ from typing import Union, List, Dict, Callable, Any  # noqa: F401
 
 class KycStatusResponse(XummResource):
 
+    required = {
+        'kyc_status': True,
+        'possible_statuses': True,
+    }
+
     model_types = {
-        'kyc_status': 'str',
-        'possible_statuses': 'dict(str, object)'
+        'kyc_status': str,
+        'possible_statuses': dict
     }
 
     attribute_map = {
@@ -27,7 +32,7 @@ class KycStatusResponse(XummResource):
         :return: The KycStatusResponse of this KycStatusResponse.  # noqa: E501
         :rtype: KycStatusResponse
         """
-        # print(json.dumps(kwargs, indent=4, sort_keys=True))
+        cls.sanity_check(kwargs)
         cls._kyc_status = None
         cls._possible_statuses = None
         cls.kyc_status = kwargs['kycStatus']
@@ -37,7 +42,7 @@ class KycStatusResponse(XummResource):
         """Returns the model properties as a dict"""
         result = {}
 
-        for attr, _ in six.iteritems(cls.model_types):
+        for attr, _ in six.iteritems(cls.attribute_map):
             value = getattr(cls, attr)
             attr = cls.attribute_map[attr]
             if isinstance(value, list):

--- a/xumm/resource/types/meta/pong.py
+++ b/xumm/resource/types/meta/pong.py
@@ -9,16 +9,20 @@ from .application_details import ApplicationDetails
 
 class PongResponse(XummResource):
 
+    required = {
+        'pong': True,
+        'auth': True
+    }
+
     model_types = {
-        'pong': 'bool',
-        'auth': 'ApplicationDetails'
+        'pong': bool,
+        'auth': dict
     }
 
     attribute_map = {
         'pong': 'pong',
         'auth': 'auth',
     }
-        
 
     def refresh_from(cls, **kwargs):
         """Returns the dict as a model
@@ -28,7 +32,7 @@ class PongResponse(XummResource):
         :return: The PongResponse of this PongResponse.  # noqa: E501
         :rtype: PongResponse
         """
-        # print(json.dumps(kwargs, indent=4, sort_keys=True))
+        cls.sanity_check(kwargs)
         cls._pong = None
         cls._auth = None
         cls.pong = kwargs['pong']
@@ -38,7 +42,7 @@ class PongResponse(XummResource):
         """Returns the model properties as a dict"""
         result = {}
 
-        for attr, _ in six.iteritems(cls.model_types):
+        for attr, _ in six.iteritems(cls.attribute_map):
             value = getattr(cls, attr)
             attr = cls.attribute_map[attr]
             if isinstance(value, list):

--- a/xumm/resource/types/meta/xrpl_transaction.py
+++ b/xumm/resource/types/meta/xrpl_transaction.py
@@ -5,455 +5,481 @@ from xumm.resource import XummResource
 import six
 from typing import Union, List, Dict, Callable, Any  # noqa: F401
 
+# class TxMeta(XummResource):
 
-class TxMeta(XummResource):
+#     required = {
+#         'transaction_index': 'int',
+#         'transaction_result': 'str',
+#         'delivered_amount': 'str'
+#     }
 
-    model_types = {
-        'transaction_index': 'int',
-        'transaction_result': 'str',
-        'delivered_amount': 'str'
-    }
+#     model_types = {
+#         'transaction_index': 'int',
+#         'transaction_result': 'str',
+#         'delivered_amount': 'str'
+#     }
 
-    attribute_map = {
-        'transaction_index': 'TransactionIndex',
-        'transaction_result': 'TransactionResult',
-        'delivered_amount': 'delivered_amount'
-    }
+#     attribute_map = {
+#         'transaction_index': 'TransactionIndex',
+#         'transaction_result': 'TransactionResult',
+#         'delivered_amount': 'delivered_amount'
+#     }
 
-    def refresh_from(cls, **kwargs):
-        """Returns the dict as a model
+#     def refresh_from(cls, **kwargs):
+#         """Returns the dict as a model
 
-        :param kwargs: A dict.
-        :type: dict
-        :return: The TxMeta of this TxMeta.  # noqa: E501
-        :rtype: TxMeta
-        """
-        cls._transaction_index = None
-        cls._transaction_result = None
-        cls._delivered_amount = None
-        cls.transaction_index = kwargs['TransactionIndex']
-        cls.transaction_result = kwargs['TransactionResult']
-        cls.delivered_amount = kwargs['delivered_amount']
+#         :param kwargs: A dict.
+#         :type: dict
+#         :return: The TxMeta of this TxMeta.  # noqa: E501
+#         :rtype: TxMeta
+#         """
+#         cls.sanity_check(kwargs)
+#         cls._transaction_index = None
+#         cls._transaction_result = None
+#         cls._delivered_amount = None
+#         cls.transaction_index = kwargs['TransactionIndex']
+#         cls.transaction_result = kwargs['TransactionResult']
+#         cls.delivered_amount = kwargs['delivered_amount']
     
-    def to_dict(cls):
-        """Returns the model properties as a dict"""
-        result = {}
+#     def to_dict(cls):
+#         """Returns the model properties as a dict"""
+#         result = {}
 
-        for attr, _ in six.iteritems(cls.model_types):
-            value = getattr(cls, attr)
-            attr = cls.attribute_map[attr]
-            if isinstance(value, list):
-                result[attr] = list(map(
-                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
-                    value
-                ))
-            elif hasattr(value, "to_dict"):
-                result[attr] = value.to_dict()
-            elif isinstance(value, dict):
-                result[attr] = dict(map(
-                    lambda item: (item[0], item[1].to_dict())
-                    if hasattr(item[1], "to_dict") else item,
-                    value.items()
-                ))
-            else:
-                result[attr] = value
-        if issubclass(TxMeta, dict):
-            for key, value in cls.items():
-                result[key] = value
+#         for attr, _ in six.iteritems(cls.model_types):
+#             value = getattr(cls, attr)
+#             attr = cls.attribute_map[attr]
+#             if isinstance(value, list):
+#                 result[attr] = list(map(
+#                     lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+#                     value
+#                 ))
+#             elif hasattr(value, "to_dict"):
+#                 result[attr] = value.to_dict()
+#             elif isinstance(value, dict):
+#                 result[attr] = dict(map(
+#                     lambda item: (item[0], item[1].to_dict())
+#                     if hasattr(item[1], "to_dict") else item,
+#                     value.items()
+#                 ))
+#             else:
+#                 result[attr] = value
+#         if issubclass(TxMeta, dict):
+#             for key, value in cls.items():
+#                 result[key] = value
 
-        return {k: v for k, v in result.items() if v is not None}
+#         return {k: v for k, v in result.items() if v is not None}
 
-    @property
-    def transaction_index(cls) -> int:
-        """Gets the transaction_index of this TxMeta.
-
-
-        :return: The transaction_index of this TxMeta.
-        :rtype: int
-        """
-        return cls._transaction_index
-
-    @transaction_index.setter
-    def transaction_index(cls, transaction_index: int):
-        """Sets the transaction_index of this TxMeta.
+#     @property
+#     def transaction_index(cls) -> int:
+#         """Gets the transaction_index of this TxMeta.
 
 
-        :param transaction_index: The transaction_index of this TxMeta.
-        :type transaction_index: int
-        """
-        if transaction_index is None:
-            raise ValueError("Invalid value for `transaction_index`, must not be `None`")  # noqa: E501
+#         :return: The transaction_index of this TxMeta.
+#         :rtype: int
+#         """
+#         return cls._transaction_index
 
-        cls._transaction_index = transaction_index
-
-    @property
-    def transaction_result(cls) -> str:
-        """Gets the transaction_result of this TxMeta.
+#     @transaction_index.setter
+#     def transaction_index(cls, transaction_index: int):
+#         """Sets the transaction_index of this TxMeta.
 
 
-        :return: The transaction_result of this TxMeta.
-        :rtype: str
-        """
-        return cls._transaction_result
+#         :param transaction_index: The transaction_index of this TxMeta.
+#         :type transaction_index: int
+#         """
+#         if transaction_index is None:
+#             raise ValueError("Invalid value for `transaction_index`, must not be `None`")  # noqa: E501
 
-    @transaction_result.setter
-    def transaction_result(cls, transaction_result: str):
-        """Sets the transaction_result of this TxMeta.
+#         cls._transaction_index = transaction_index
 
-
-        :param transaction_result: The transaction_result of this TxMeta.
-        :type transaction_result: str
-        """
-        if transaction_result is None:
-            raise ValueError("Invalid value for `transaction_result`, must not be `None`")  # noqa: E501
-
-        cls._transaction_result = transaction_result
-
-    @property
-    def delivered_amount(cls) -> str:
-        """Gets the delivered_amount of this TxMeta.
+#     @property
+#     def transaction_result(cls) -> str:
+#         """Gets the transaction_result of this TxMeta.
 
 
-        :return: The delivered_amount of this TxMeta.
-        :rtype: str
-        """
-        return cls._delivered_amount
+#         :return: The transaction_result of this TxMeta.
+#         :rtype: str
+#         """
+#         return cls._transaction_result
 
-    @delivered_amount.setter
-    def delivered_amount(cls, delivered_amount: str):
-        """Sets the delivered_amount of this TxMeta.
+#     @transaction_result.setter
+#     def transaction_result(cls, transaction_result: str):
+#         """Sets the transaction_result of this TxMeta.
 
 
-        :param delivered_amount: The delivered_amount of this TxMeta.
-        :type delivered_amount: str
-        """
-        if delivered_amount is None:
-            raise ValueError("Invalid value for `delivered_amount`, must not be `None`")  # noqa: E501
+#         :param transaction_result: The transaction_result of this TxMeta.
+#         :type transaction_result: str
+#         """
+#         if transaction_result is None:
+#             raise ValueError("Invalid value for `transaction_result`, must not be `None`")  # noqa: E501
 
-        cls._delivered_amount = delivered_amount
+#         cls._transaction_result = transaction_result
 
-class Transaction(XummResource):
+#     @property
+#     def delivered_amount(cls) -> str:
+#         """Gets the delivered_amount of this TxMeta.
 
-    model_types = {
-        'account': 'str',
-        'amount': 'str',
-        'destination': 'str',
-        'fee': 'str',
-        'flags': 'int',
-        'sequence': 'int',
-        'signing_pub_key': 'str',
-        'transaction_type': 'str',
-        'meta': 'TxMeta',
-        'validated': 'bool'
-    }
 
-    attribute_map = {
-        'account': 'Account',
-        'amount': 'Amount',
-        'destination': 'Destination',
-        'fee': 'Fee',
-        'flags': 'Flags',
-        'sequence': 'Sequence',
-        'signing_pub_key': 'SigningPubKey',
-        'transaction_type': 'TransactionType',
-        'meta': 'meta',
-        'validated': 'validated'
-    }
+#         :return: The delivered_amount of this TxMeta.
+#         :rtype: str
+#         """
+#         return cls._delivered_amount
 
-    def refresh_from(cls, **kwargs):
-        """Returns the dict as a model
+#     @delivered_amount.setter
+#     def delivered_amount(cls, delivered_amount: str):
+#         """Sets the delivered_amount of this TxMeta.
 
-        :param kwargs: A dict.
-        :type: dict
-        :return: The Transaction of this Transaction.  # noqa: E501
-        :rtype: Transaction
-        """
-        cls._account = None
-        cls._amount = None
-        cls._destination = None
-        cls._fee = None
-        cls._flags = None
-        cls._sequence = None
-        cls._signing_pub_key = None
-        cls._transaction_type = None
-        cls._meta = None
-        cls._validated = None
-        cls.account = kwargs['Account']
-        cls.amount = kwargs['Amount']
-        cls.destination = kwargs['Destination']
-        cls.fee = kwargs['Fee']
-        cls.flags = kwargs['Flags']
-        cls.sequence = kwargs['Sequence']
-        cls.signing_pub_key = kwargs['SigningPubKey']
-        cls.transaction_type = kwargs['TransactionType']
-        cls.meta = TxMeta(**kwargs['meta'])
-        cls.validated = kwargs['validated']
+
+#         :param delivered_amount: The delivered_amount of this TxMeta.
+#         :type delivered_amount: str
+#         """
+#         if delivered_amount is None:
+#             raise ValueError("Invalid value for `delivered_amount`, must not be `None`")  # noqa: E501
+
+#         cls._delivered_amount = delivered_amount
+
+# class Transaction(XummResource):
+
+#     required = {
+#         'account': 'str',
+#         'amount': 'str',
+#         'destination': 'str',
+#         'fee': 'str',
+#         'flags': 'int',
+#         'sequence': 'int',
+#         'signing_pub_key': 'str',
+#         'transaction_type': 'str',
+#         'meta': 'TxMeta',
+#         'validated': 'bool'
+#     }
     
-    def to_dict(cls):
-        """Returns the model properties as a dict"""
-        result = {}
+#     model_types = {
+#         'account': 'str',
+#         'amount': 'str',
+#         'destination': 'str',
+#         'fee': 'str',
+#         'flags': 'int',
+#         'sequence': 'int',
+#         'signing_pub_key': 'str',
+#         'transaction_type': 'str',
+#         'meta': 'TxMeta',
+#         'validated': 'bool'
+#     }
+
+#     attribute_map = {
+#         'account': 'Account',
+#         'amount': 'Amount',
+#         'destination': 'Destination',
+#         'fee': 'Fee',
+#         'flags': 'Flags',
+#         'sequence': 'Sequence',
+#         'signing_pub_key': 'SigningPubKey',
+#         'transaction_type': 'TransactionType',
+#         'meta': 'meta',
+#         'validated': 'validated'
+#     }
+
+#     def refresh_from(cls, **kwargs):
+#         """Returns the dict as a model
+
+#         :param kwargs: A dict.
+#         :type: dict
+#         :return: The Transaction of this Transaction.  # noqa: E501
+#         :rtype: Transaction
+#         """
+#         cls.sanity_check(kwargs)
+#         cls._account = None
+#         cls._amount = None
+#         cls._destination = None
+#         cls._fee = None
+#         cls._flags = None
+#         cls._sequence = None
+#         cls._signing_pub_key = None
+#         cls._transaction_type = None
+#         cls._meta = None
+#         cls._validated = None
+#         cls.account = kwargs['Account']
+#         cls.amount = kwargs['Amount']
+#         cls.destination = kwargs['Destination']
+#         cls.fee = kwargs['Fee']
+#         cls.flags = kwargs['Flags']
+#         cls.sequence = kwargs['Sequence']
+#         cls.signing_pub_key = kwargs['SigningPubKey']
+#         cls.transaction_type = kwargs['TransactionType']
+#         cls.meta = TxMeta(**kwargs['meta'])
+#         cls.validated = kwargs['validated']
+    
+#     def to_dict(cls):
+#         """Returns the model properties as a dict"""
+#         result = {}
+
+#         for attr, _ in six.iteritems(cls.model_types):
+#             value = getattr(cls, attr)
+#             attr = cls.attribute_map[attr]
+#             if isinstance(value, list):
+#                 result[attr] = list(map(
+#                     lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+#                     value
+#                 ))
+#             elif hasattr(value, "to_dict"):
+#                 result[attr] = value.to_dict()
+#             elif isinstance(value, dict):
+#                 result[attr] = dict(map(
+#                     lambda item: (item[0], item[1].to_dict())
+#                     if hasattr(item[1], "to_dict") else item,
+#                     value.items()
+#                 ))
+#             else:
+#                 result[attr] = value
+#         if issubclass(Transaction, dict):
+#             for key, value in cls.items():
+#                 result[key] = value
+
+#         return {k: v for k, v in result.items() if v is not None}
+
+#     @property
+#     def account(cls) -> str:
+#         """Gets the account of this Transaction.
+
+
+#         :return: The account of this Transaction.
+#         :rtype: str
+#         """
+#         return cls._account
+
+#     @account.setter
+#     def account(cls, account: str):
+#         """Sets the account of this Transaction.
+
+
+#         :param account: The account of this Transaction.
+#         :type account: str
+#         """
+#         if account is None:
+#             raise ValueError("Invalid value for `account`, must not be `None`")  # noqa: E501
 
-        for attr, _ in six.iteritems(cls.model_types):
-            value = getattr(cls, attr)
-            attr = cls.attribute_map[attr]
-            if isinstance(value, list):
-                result[attr] = list(map(
-                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
-                    value
-                ))
-            elif hasattr(value, "to_dict"):
-                result[attr] = value.to_dict()
-            elif isinstance(value, dict):
-                result[attr] = dict(map(
-                    lambda item: (item[0], item[1].to_dict())
-                    if hasattr(item[1], "to_dict") else item,
-                    value.items()
-                ))
-            else:
-                result[attr] = value
-        if issubclass(Transaction, dict):
-            for key, value in cls.items():
-                result[key] = value
+#         cls._account = account
 
-        return {k: v for k, v in result.items() if v is not None}
+#     @property
+#     def amount(cls) -> str:
+#         """Gets the amount of this Transaction.
 
-    @property
-    def account(cls) -> str:
-        """Gets the account of this Transaction.
 
+#         :return: The amount of this Transaction.
+#         :rtype: str
+#         """
+#         return cls._amount
 
-        :return: The account of this Transaction.
-        :rtype: str
-        """
-        return cls._account
+#     @amount.setter
+#     def amount(cls, amount: str):
+#         """Sets the amount of this Transaction.
 
-    @account.setter
-    def account(cls, account: str):
-        """Sets the account of this Transaction.
 
+#         :param amount: The amount of this Transaction.
+#         :type amount: str
+#         """
+#         if amount is None:
+#             raise ValueError("Invalid value for `amount`, must not be `None`")  # noqa: E501
 
-        :param account: The account of this Transaction.
-        :type account: str
-        """
-        if account is None:
-            raise ValueError("Invalid value for `account`, must not be `None`")  # noqa: E501
+#         cls._amount = amount
 
-        cls._account = account
+#     @property
+#     def destination(cls) -> str:
+#         """Gets the destination of this Transaction.
 
-    @property
-    def amount(cls) -> str:
-        """Gets the amount of this Transaction.
 
+#         :return: The destination of this Transaction.
+#         :rtype: str
+#         """
+#         return cls._destination
 
-        :return: The amount of this Transaction.
-        :rtype: str
-        """
-        return cls._amount
+#     @destination.setter
+#     def destination(cls, destination: str):
+#         """Sets the destination of this Transaction.
 
-    @amount.setter
-    def amount(cls, amount: str):
-        """Sets the amount of this Transaction.
 
+#         :param destination: The destination of this Transaction.
+#         :type destination: str
+#         """
+#         if destination is None:
+#             raise ValueError("Invalid value for `destination`, must not be `None`")  # noqa: E501
 
-        :param amount: The amount of this Transaction.
-        :type amount: str
-        """
-        if amount is None:
-            raise ValueError("Invalid value for `amount`, must not be `None`")  # noqa: E501
+#         cls._destination = destination
 
-        cls._amount = amount
+#     @property
+#     def fee(cls) -> str:
+#         """Gets the fee of this Transaction.
 
-    @property
-    def destination(cls) -> str:
-        """Gets the destination of this Transaction.
 
+#         :return: The fee of this Transaction.
+#         :rtype: str
+#         """
+#         return cls._fee
 
-        :return: The destination of this Transaction.
-        :rtype: str
-        """
-        return cls._destination
+#     @fee.setter
+#     def fee(cls, fee: str):
+#         """Sets the fee of this Transaction.
 
-    @destination.setter
-    def destination(cls, destination: str):
-        """Sets the destination of this Transaction.
 
+#         :param fee: The fee of this Transaction.
+#         :type fee: str
+#         """
+#         if fee is None:
+#             raise ValueError("Invalid value for `fee`, must not be `None`")  # noqa: E501
 
-        :param destination: The destination of this Transaction.
-        :type destination: str
-        """
-        if destination is None:
-            raise ValueError("Invalid value for `destination`, must not be `None`")  # noqa: E501
+#         cls._fee = fee
 
-        cls._destination = destination
+#     @property
+#     def flags(cls) -> int:
+#         """Gets the flags of this Transaction.
 
-    @property
-    def fee(cls) -> str:
-        """Gets the fee of this Transaction.
 
+#         :return: The flags of this Transaction.
+#         :rtype: int
+#         """
+#         return cls._flags
 
-        :return: The fee of this Transaction.
-        :rtype: str
-        """
-        return cls._fee
+#     @flags.setter
+#     def flags(cls, flags: int):
+#         """Sets the flags of this Transaction.
 
-    @fee.setter
-    def fee(cls, fee: str):
-        """Sets the fee of this Transaction.
 
+#         :param flags: The flags of this Transaction.
+#         :type flags: int
+#         """
+#         if flags is None:
+#             raise ValueError("Invalid value for `flags`, must not be `None`")  # noqa: E501
 
-        :param fee: The fee of this Transaction.
-        :type fee: str
-        """
-        if fee is None:
-            raise ValueError("Invalid value for `fee`, must not be `None`")  # noqa: E501
+#         cls._flags = flags
 
-        cls._fee = fee
+#     @property
+#     def sequence(cls) -> int:
+#         """Gets the sequence of this Transaction.
 
-    @property
-    def flags(cls) -> int:
-        """Gets the flags of this Transaction.
 
+#         :return: The sequence of this Transaction.
+#         :rtype: int
+#         """
+#         return cls._sequence
 
-        :return: The flags of this Transaction.
-        :rtype: int
-        """
-        return cls._flags
+#     @sequence.setter
+#     def sequence(cls, sequence: int):
+#         """Sets the sequence of this Transaction.
 
-    @flags.setter
-    def flags(cls, flags: int):
-        """Sets the flags of this Transaction.
 
+#         :param sequence: The sequence of this Transaction.
+#         :type sequence: int
+#         """
+#         if sequence is None:
+#             raise ValueError("Invalid value for `sequence`, must not be `None`")  # noqa: E501
 
-        :param flags: The flags of this Transaction.
-        :type flags: int
-        """
-        if flags is None:
-            raise ValueError("Invalid value for `flags`, must not be `None`")  # noqa: E501
+#         cls._sequence = sequence
 
-        cls._flags = flags
+#     @property
+#     def signing_pub_key(cls) -> str:
+#         """Gets the signing_pub_key of this Transaction.
 
-    @property
-    def sequence(cls) -> int:
-        """Gets the sequence of this Transaction.
 
+#         :return: The signing_pub_key of this Transaction.
+#         :rtype: str
+#         """
+#         return cls._signing_pub_key
 
-        :return: The sequence of this Transaction.
-        :rtype: int
-        """
-        return cls._sequence
+#     @signing_pub_key.setter
+#     def signing_pub_key(cls, signing_pub_key: str):
+#         """Sets the signing_pub_key of this Transaction.
 
-    @sequence.setter
-    def sequence(cls, sequence: int):
-        """Sets the sequence of this Transaction.
 
+#         :param signing_pub_key: The signing_pub_key of this Transaction.
+#         :type signing_pub_key: str
+#         """
+#         if signing_pub_key is None:
+#             raise ValueError("Invalid value for `signing_pub_key`, must not be `None`")  # noqa: E501
 
-        :param sequence: The sequence of this Transaction.
-        :type sequence: int
-        """
-        if sequence is None:
-            raise ValueError("Invalid value for `sequence`, must not be `None`")  # noqa: E501
+#         cls._signing_pub_key = signing_pub_key
 
-        cls._sequence = sequence
+#     @property
+#     def transaction_type(cls) -> str:
+#         """Gets the transaction_type of this Transaction.
 
-    @property
-    def signing_pub_key(cls) -> str:
-        """Gets the signing_pub_key of this Transaction.
 
+#         :return: The transaction_type of this Transaction.
+#         :rtype: str
+#         """
+#         return cls._transaction_type
 
-        :return: The signing_pub_key of this Transaction.
-        :rtype: str
-        """
-        return cls._signing_pub_key
+#     @transaction_type.setter
+#     def transaction_type(cls, transaction_type: str):
+#         """Sets the transaction_type of this Transaction.
 
-    @signing_pub_key.setter
-    def signing_pub_key(cls, signing_pub_key: str):
-        """Sets the signing_pub_key of this Transaction.
 
+#         :param transaction_type: The transaction_type of this Transaction.
+#         :type transaction_type: str
+#         """
+#         if transaction_type is None:
+#             raise ValueError("Invalid value for `transaction_type`, must not be `None`")  # noqa: E501
 
-        :param signing_pub_key: The signing_pub_key of this Transaction.
-        :type signing_pub_key: str
-        """
-        if signing_pub_key is None:
-            raise ValueError("Invalid value for `signing_pub_key`, must not be `None`")  # noqa: E501
+#         cls._transaction_type = transaction_type
 
-        cls._signing_pub_key = signing_pub_key
+#     @property
+#     def meta(cls) -> TxMeta:
+#         """Gets the meta of this Transaction.
 
-    @property
-    def transaction_type(cls) -> str:
-        """Gets the transaction_type of this Transaction.
 
+#         :return: The meta of this Transaction.
+#         :rtype: TxMeta
+#         """
+#         return cls._meta
 
-        :return: The transaction_type of this Transaction.
-        :rtype: str
-        """
-        return cls._transaction_type
+#     @meta.setter
+#     def meta(cls, meta: TxMeta):
+#         """Sets the meta of this Transaction.
 
-    @transaction_type.setter
-    def transaction_type(cls, transaction_type: str):
-        """Sets the transaction_type of this Transaction.
 
+#         :param meta: The meta of this Transaction.
+#         :type meta: TxMeta
+#         """
+#         if meta is None:
+#             raise ValueError("Invalid value for `meta`, must not be `None`")  # noqa: E501
 
-        :param transaction_type: The transaction_type of this Transaction.
-        :type transaction_type: str
-        """
-        if transaction_type is None:
-            raise ValueError("Invalid value for `transaction_type`, must not be `None`")  # noqa: E501
+#         cls._meta = meta
 
-        cls._transaction_type = transaction_type
+#     @property
+#     def validated(cls) -> bool:
+#         """Gets the validated of this Transaction.
 
-    @property
-    def meta(cls) -> TxMeta:
-        """Gets the meta of this Transaction.
 
+#         :return: The validated of this Transaction.
+#         :rtype: bool
+#         """
+#         return cls._validated
 
-        :return: The meta of this Transaction.
-        :rtype: TxMeta
-        """
-        return cls._meta
+#     @validated.setter
+#     def validated(cls, validated: bool):
+#         """Sets the validated of this Transaction.
 
-    @meta.setter
-    def meta(cls, meta: TxMeta):
-        """Sets the meta of this Transaction.
 
+#         :param validated: The validated of this Transaction.
+#         :type validated: bool
+#         """
+#         if validated is None:
+#             raise ValueError("Invalid value for `validated`, must not be `None`")  # noqa: E501
 
-        :param meta: The meta of this Transaction.
-        :type meta: TxMeta
-        """
-        if meta is None:
-            raise ValueError("Invalid value for `meta`, must not be `None`")  # noqa: E501
-
-        cls._meta = meta
-
-    @property
-    def validated(cls) -> bool:
-        """Gets the validated of this Transaction.
-
-
-        :return: The validated of this Transaction.
-        :rtype: bool
-        """
-        return cls._validated
-
-    @validated.setter
-    def validated(cls, validated: bool):
-        """Sets the validated of this Transaction.
-
-
-        :param validated: The validated of this Transaction.
-        :type validated: bool
-        """
-        if validated is None:
-            raise ValueError("Invalid value for `validated`, must not be `None`")  # noqa: E501
-
-        cls._validated = validated
+#         cls._validated = validated
 
 
 class BalanceChange(XummResource):
 
+    required = {
+        'counterparty': True,
+        'currency': True,
+        'value': True,
+    }
+
     model_types = {
-        'counterparty': 'str',
-        'currency': 'str',
-        'value': 'str'
+        'counterparty': str,
+        'currency': str,
+        'value': str
     }
 
     attribute_map = {
@@ -470,6 +496,7 @@ class BalanceChange(XummResource):
         :return: The BalanceChange of this BalanceChange.  # noqa: E501
         :rtype: BalanceChange
         """
+        cls.sanity_check(kwargs)
         cls._counterparty = None
         cls._currency = None
         cls._value = None
@@ -481,7 +508,7 @@ class BalanceChange(XummResource):
         """Returns the model properties as a dict"""
         result = {}
 
-        for attr, _ in six.iteritems(cls.model_types):
+        for attr, _ in six.iteritems(cls.attribute_map):
             value = getattr(cls, attr)
             attr = cls.attribute_map[attr]
             if isinstance(value, list):
@@ -571,11 +598,18 @@ class BalanceChange(XummResource):
 
 class XrplTransaction(XummResource):
 
+    # Review..
+    required = {
+        'txid': True,
+        'node': True,
+        'transaction': True,
+    }
+
     model_types = {
-        'txid': 'str',
-        'balance_changes': 'dict(str, BalanceChange)',
-        'node': 'str',
-        'transaction': 'Transaction'
+        'txid': str,
+        'balance_changes': dict,
+        'node': str,
+        'transaction': dict
     }
 
     attribute_map = {
@@ -594,7 +628,7 @@ class XrplTransaction(XummResource):
         :return: The XrplTransaction of this XrplTransaction.  # noqa: E501
         :rtype: XrplTransaction
         """
-        # print(json.dumps(kwargs, indent=4, sort_keys=True))
+        cls.sanity_check(kwargs)
         cls._txid = None
         cls._balance_changes = None
         cls._node = None
@@ -602,13 +636,13 @@ class XrplTransaction(XummResource):
         cls.txid = kwargs['txid']
         cls.balance_changes = {k: [BalanceChange(**b).to_dict() for b in v] for k, v in kwargs['balanceChanges'].items()}
         cls.node = kwargs['node']
-        cls.transaction = Transaction(**kwargs['transaction'])
+        cls.transaction = kwargs['transaction']
 
     def to_dict(cls):
         """Returns the model properties as a dict"""
         result = {}
 
-        for attr, _ in six.iteritems(cls.model_types):
+        for attr, _ in six.iteritems(cls.attribute_map):
             value = getattr(cls, attr)
             attr = cls.attribute_map[attr]
             # if attr == 'balanceChanges':
@@ -704,22 +738,22 @@ class XrplTransaction(XummResource):
         cls._node = node
 
     @property
-    def transaction(cls) -> Transaction:
+    def transaction(cls) -> Dict[str, Any]:
         """Gets the transaction of this XrplTransaction.
 
 
         :return: The transaction of this XrplTransaction.
-        :rtype: Transaction
+        :rtype: Dict[str, Any]
         """
         return cls._transaction
 
     @transaction.setter
-    def transaction(cls, transaction: Transaction):
+    def transaction(cls, transaction: Dict[str, Any]):
         """Sets the transaction of this XrplTransaction.
 
 
         :param transaction: The transaction of this XrplTransaction.
-        :type transaction: Transaction
+        :type transaction: Dict[str, Any]
         """
         if transaction is None:
             raise ValueError("Invalid value for `transaction`, must not be `None`")  # noqa: E501

--- a/xumm/resource/types/payload/payload_and_subscription.py
+++ b/xumm/resource/types/payload/payload_and_subscription.py
@@ -23,12 +23,21 @@ class PayloadAndSubscription(XummResource):
       attribute_map (dict): The key is attribute name
                             and the value is json key in definition.
     """
+
+    required = {
+        'created': True,
+        'payload': True,
+        'resolve': True,
+        'resolved': True,
+        'websocket': True,
+    }
+
     model_types = {
-        'created': 'CreatedPayload',
-        'payload': 'XummPayload',
-        'resolve': 'Callable[[Any], Any]',
-        'resolved': 'Callable[[Any], Any]',
-        'websocket': 'WSClient',
+        'created': dict,
+        'payload': dict,
+        'resolve': Callable,
+        'resolved': Callable,
+        'websocket': WSClient,
     }
 
     attribute_map = {
@@ -47,6 +56,7 @@ class PayloadAndSubscription(XummResource):
         :return: The PayloadAndSubscription of this PayloadAndSubscription.  # noqa: E501
         :rtype: PayloadAndSubscription
         """
+        cls.sanity_check(kwargs)
         cls._payload = None
         cls._resolve = None
         cls._resolved = None
@@ -60,7 +70,7 @@ class PayloadAndSubscription(XummResource):
         """Returns the model properties as a dict"""
         result = {}
 
-        for attr, _ in six.iteritems(cls.model_types):
+        for attr, _ in six.iteritems(cls.attribute_map):
             value = getattr(cls, attr)
             attr = cls.attribute_map[attr]
             if attr == 'websocket' or attr == 'resolve':

--- a/xumm/resource/types/payload/payload_subscription.py
+++ b/xumm/resource/types/payload/payload_subscription.py
@@ -23,11 +23,18 @@ class PayloadSubscription(XummResource):
       attribute_map (dict): The key is attribute name
                             and the value is json key in definition.
     """
+    required = {
+        'payload': True,
+        'resolved': True,
+        'resolve': True,
+        'websocket': True,
+    }
+
     model_types = {
-        'payload': 'XummPayload',
-        'resolved': 'Callable[[Any], Any]',
-        'resolve': 'Callable[[Any], Any]',
-        'websocket': 'WSClient',
+        'payload': dict,
+        'resolved': Callable,
+        'resolve': Callable,
+        'websocket': WSClient,
     }
 
     attribute_map = {
@@ -46,6 +53,7 @@ class PayloadSubscription(XummResource):
         :return: The PayloadSubscription of this PayloadSubscription.  # noqa: E501
         :rtype: PayloadSubscription
         """
+        cls.sanity_check(kwargs)
         cls._payload = None
         cls._resolved = None
         cls._resolve = None
@@ -59,7 +67,7 @@ class PayloadSubscription(XummResource):
         """Returns the model properties as a dict"""
         result = {}
 
-        for attr, _ in six.iteritems(cls.model_types):
+        for attr, _ in six.iteritems(cls.attribute_map):
             value = getattr(cls, attr)
             attr = cls.attribute_map[attr]
             if attr == 'websocket' or attr == 'resolve':

--- a/xumm/resource/types/payload/subscription_callback_params.py
+++ b/xumm/resource/types/payload/subscription_callback_params.py
@@ -22,11 +22,18 @@ class SubscriptionCallbackParams(XummResource):
       attribute_map (dict): The key is attribute name
                             and the value is json key in definition.
     """
+    required = {
+        'uuid': True,
+        'data': True,
+        'payload': True,
+        'resolve': True,
+    }
+
     model_types = {
-        'uuid': 'str',
-        'data': 'dict(str, any)',
-        'payload': 'XummPayload',
-        'resolve': 'Callable[[Any], Any]',
+        'uuid': str,
+        'data': dict,
+        'payload': dict,
+        'resolve': Callable,
     }
 
     attribute_map = {
@@ -45,6 +52,7 @@ class SubscriptionCallbackParams(XummResource):
         :return: The PayloadSubscription of this PayloadSubscription.  # noqa: E501
         :rtype: PayloadSubscription
         """
+        cls.sanity_check(kwargs)
         cls._uuid = None
         cls._data = None
         cls._payload = None

--- a/xumm/resource/types/storage/storage_delete_response.py
+++ b/xumm/resource/types/storage/storage_delete_response.py
@@ -15,10 +15,16 @@ class StorageDeleteResponse(XummResource):
       attribute_map (dict): The key is attribute name
                             and the value is json key in definition.
     """
+    required = {
+        'application': True,
+        'stored': True,
+        'data': True,
+    }
+
     model_types = {
-        'application': 'StorageResponse',
-        'stored': 'bool',
-        'data': '(str, object)',
+        'application': dict,
+        'stored': bool,
+        'data': dict,
     }
 
     attribute_map = {
@@ -36,6 +42,7 @@ class StorageDeleteResponse(XummResource):
         :return: The StorageDeleteResponse of this StorageDeleteResponse.  # noqa: E501
         :rtype: StorageDeleteResponse
         """
+        cls.sanity_check(kwargs)
         cls._application = None
         cls._stored = None
         cls._data = None
@@ -47,7 +54,7 @@ class StorageDeleteResponse(XummResource):
         """Returns the model properties as a dict"""
         result = {}
 
-        for attr, _ in six.iteritems(cls.model_types):
+        for attr, _ in six.iteritems(cls.attribute_map):
             value = getattr(cls, attr)
             attr = cls.attribute_map[attr]
             if isinstance(value, list):

--- a/xumm/resource/types/storage/storage_get_response.py
+++ b/xumm/resource/types/storage/storage_get_response.py
@@ -15,9 +15,14 @@ class StorageGetResponse(XummResource):
       attribute_map (dict): The key is attribute name
                             and the value is json key in definition.
     """
+    required = {
+        'application': True,
+        'data': True,
+    }
+
     model_types = {
-        'application': 'StorageResponse',
-        'data': '(str, object)',
+        'application': dict,
+        'data': dict,
     }
 
     attribute_map = {
@@ -34,7 +39,7 @@ class StorageGetResponse(XummResource):
         :return: The StorageGetResponse of this StorageGetResponse.  # noqa: E501
         :rtype: StorageGetResponse
         """
-        # print(json.dumps(kwargs, indent=4, sort_keys=True))
+        cls.sanity_check(kwargs)
         cls._application = None
         cls._data = None
         cls.application = StorageResponse(**kwargs['application'])
@@ -44,7 +49,7 @@ class StorageGetResponse(XummResource):
         """Returns the model properties as a dict"""
         result = {}
 
-        for attr, _ in six.iteritems(cls.model_types):
+        for attr, _ in six.iteritems(cls.attribute_map):
             value = getattr(cls, attr)
             attr = cls.attribute_map[attr]
             if isinstance(value, list):

--- a/xumm/resource/types/storage/storage_response.py
+++ b/xumm/resource/types/storage/storage_response.py
@@ -6,9 +6,14 @@ import six
 
 class StorageResponse(XummResource):
 
+    required = {
+        'name': True,
+        'uuidv4': True
+    }
+
     model_types = {
-        'name': 'str',
-        'uuidv4': 'str'
+        'name': str,
+        'uuidv4': str
     }
 
     attribute_map = {
@@ -24,6 +29,7 @@ class StorageResponse(XummResource):
         :return: The StorageResponse of this StorageResponse.  # noqa: E501
         :rtype: StorageResponse
         """
+        cls.sanity_check(kwargs)
         cls._name = None
         cls._uuidv4 = None
         cls.name = kwargs['name']
@@ -33,7 +39,7 @@ class StorageResponse(XummResource):
         """Returns the model properties as a dict"""
         result = {}
 
-        for attr, _ in six.iteritems(cls.model_types):
+        for attr, _ in six.iteritems(cls.attribute_map):
             value = getattr(cls, attr)
             attr = cls.attribute_map[attr]
             if isinstance(value, list):

--- a/xumm/resource/types/storage/storage_set_response.py
+++ b/xumm/resource/types/storage/storage_set_response.py
@@ -15,10 +15,16 @@ class StorageSetResponse(XummResource):
       attribute_map (dict): The key is attribute name
                             and the value is json key in definition.
     """
+    required = {
+        'application': True,
+        'stored': True,
+        'data': True,
+    }
+
     model_types = {
-        'application': 'StorageResponse',
-        'stored': 'bool',
-        'data': '(str, object)',
+        'application': dict,
+        'stored': bool,
+        'data': dict,
     }
 
     attribute_map = {
@@ -36,6 +42,7 @@ class StorageSetResponse(XummResource):
         :return: The StorageSetResponse of this StorageSetResponse.  # noqa: E501
         :rtype: StorageSetResponse
         """
+        cls.sanity_check(kwargs)
         cls._application = None
         cls._stored = None
         cls._data = None
@@ -47,7 +54,7 @@ class StorageSetResponse(XummResource):
         """Returns the model properties as a dict"""
         result = {}
 
-        for attr, _ in six.iteritems(cls.model_types):
+        for attr, _ in six.iteritems(cls.attribute_map):
             value = getattr(cls, attr)
             attr = cls.attribute_map[attr]
             if isinstance(value, list):

--- a/xumm/resource/types/xumm_api/__init__.py
+++ b/xumm/resource/types/xumm_api/__init__.py
@@ -90,10 +90,12 @@ class XummCustomMeta(XummResource):
       attribute_map (dict): The key is attribute name
                             and the value is json key in definition.
     """
+    required = {}
+
     model_types = {
-        'identifier': 'str',
-        'blob': 'dict(str, object)',
-        'instruction': 'str'
+        'identifier': str,
+        'blob': dict,
+        'instruction': str
     }
 
     attribute_map = {
@@ -110,6 +112,7 @@ class XummCustomMeta(XummResource):
         :return: The XummCustomMeta of this XummCustomMeta.  # noqa: E501
         :rtype: XummCustomMeta
         """
+        cls.sanity_check(kwargs)
         cls._identifier = None
         cls._blob = None
         cls._instruction = None
@@ -124,7 +127,7 @@ class XummCustomMeta(XummResource):
         """Returns the model properties as a dict"""
         result = {}
 
-        for attr, _ in six.iteritems(cls.model_types):
+        for attr, _ in six.iteritems(cls.attribute_map):
             value = getattr(cls, attr)
             attr = cls.attribute_map[attr]
             if isinstance(value, list):
@@ -245,22 +248,41 @@ class XummPayloadMeta(XummResource):
                             and the value is json key in definition.
     """
     model_types = {
-        'exists': 'bool',
-        'uuid': 'str',
-        'multisign': 'bool',
-        'submit': 'bool',
-        'destination': 'str',
-        'resolved_destination': 'str',
-        'resolved': 'bool',
-        'signed': 'bool',
-        'cancelled': 'bool',
-        'expired': 'bool',
-        'pushed': 'bool',
-        'app_opened': 'bool',
-        'opened_by_deeplink': 'bool',
-        'return_url_app': 'str',
-        'return_url_web': 'str',
-        'is_xapp': 'bool'
+        'exists': True,
+        'uuid': True,
+        'multisign': True,
+        'submit': True,
+        'destination': True,
+        'resolved_destination': True,
+        'resolved': True,
+        'signed': True,
+        'cancelled': True,
+        'expired': True,
+        'pushed': True,
+        'app_opened': True,
+        'opened_by_deeplink': True,
+        'return_url_app': True,
+        'return_url_web': True,
+        'is_xapp': True
+    }
+
+    model_types = {
+        'exists': bool,
+        'uuid': str,
+        'multisign': bool,
+        'submit': bool,
+        'destination': str,
+        'resolved_destination': str,
+        'resolved': bool,
+        'signed': bool,
+        'cancelled': bool,
+        'expired': bool,
+        'pushed': bool,
+        'app_opened': bool,
+        'opened_by_deeplink': bool,
+        'return_url_app': str,
+        'return_url_web': str,
+        'is_xapp': bool
     }
 
     attribute_map = {
@@ -290,6 +312,7 @@ class XummPayloadMeta(XummResource):
         :return: The XummPayloadMeta of this XummPayloadMeta.  # noqa: E501
         :rtype: XummPayloadMeta
         """
+        cls.sanity_check(kwargs)
         cls._exists = None
         cls._uuid = None
         cls._multisign = None
@@ -330,7 +353,7 @@ class XummPayloadMeta(XummResource):
         """Returns the model properties as a dict"""
         result = {}
 
-        for attr, _ in six.iteritems(cls.model_types):
+        for attr, _ in six.iteritems(cls.attribute_map):
             value = getattr(cls, attr)
             attr = cls.attribute_map[attr]
             if isinstance(value, list):
@@ -749,8 +772,12 @@ class XummJsonTransaction(XummResource):
                             and the value is json key in definition.
     """
 
+    required = {
+        'txjson': True
+    }
+
     model_types = {
-        'txjson': 'dict(str, object)',
+        'txjson': dict,
     }
 
     attribute_map = {
@@ -765,6 +792,7 @@ class XummJsonTransaction(XummResource):
         :return: The XummPayloadBodyBase of this XummPayloadBodyBase.  # noqa: E501
         :rtype: XummPayloadBodyBase
         """
+        cls.sanity_check(kwargs)
         cls._txjson = None
         cls.txjson = kwargs['txjson']
         
@@ -829,7 +857,15 @@ class XummPayloadBodyBase(XummResource):
       attribute_map (dict): The key is attribute name
                             and the value is json key in definition.
     """
-    swagger_types = {
+    required = {
+        'user_token': True,
+        'options': True,
+        # 'txjson': 'TxJson',
+        'custom_meta': True,
+        # 'txblob': 'str'
+    }
+
+    model_types = {
         'user_token': 'str',
         'options': 'Options',
         # 'txjson': 'TxJson',
@@ -853,6 +889,7 @@ class XummPayloadBodyBase(XummResource):
         :return: The XummPayloadBodyBase of this XummPayloadBodyBase.  # noqa: E501
         :rtype: XummPayloadBodyBase
         """
+        cls.sanity_check(kwargs)
         cls._user_token = None
         cls._options = None
         # cls._txjson = None
@@ -873,7 +910,7 @@ class XummPayloadBodyBase(XummResource):
         """Returns the model properties as a dict"""
         result = {}
 
-        for attr, _ in six.iteritems(cls.model_types):
+        for attr, _ in six.iteritems(cls.attribute_map):
             value = getattr(cls, attr)
             attr = cls.attribute_map[attr]
             if isinstance(value, list):
@@ -1101,11 +1138,18 @@ class XummPostPayloadResponse(XummResource):
       attribute_map (dict): The key is attribute name
                             and the value is json key in definition.
     """
+    required = {
+        'uuid': True,
+        'next': True,
+        'refs': True,
+        'pushed': True
+    }
+
     model_types = {
-        'uuid': 'str',
-        'next': 'Next',
-        'refs': 'Refs',
-        'pushed': 'bool'
+        'uuid': str,
+        'next': dict,
+        'refs': dict,
+        'pushed': bool
     }
 
     attribute_map = {
@@ -1124,6 +1168,7 @@ class XummPostPayloadResponse(XummResource):
         :return: The XummPostPayloadResponse of this XummPostPayloadResponse.  # noqa: E501
         :rtype: XummPostPayloadResponse
         """
+        cls.sanity_check(kwargs)
         cls._uuid = None
         cls._next = None
         cls._refs = None
@@ -1137,7 +1182,7 @@ class XummPostPayloadResponse(XummResource):
         """Returns the model properties as a dict"""
         result = {}
 
-        for attr, _ in six.iteritems(cls.model_types):
+        for attr, _ in six.iteritems(cls.attribute_map):
             value = getattr(cls, attr)
             attr = cls.attribute_map[attr]
             if isinstance(value, list):
@@ -1297,12 +1342,20 @@ class XummGetPayloadResponse(XummResource):
       attribute_map (dict): The key is attribute name
                             and the value is json key in definition.
     """
+    required = {
+        'meta': True,
+        'application': True,
+        'payload': True,
+        'response': True,
+        'custom_meta': True
+    }
+
     model_types = {
-        'meta': 'Meta',
-        'application': 'Application',
-        'payload': 'Payload',
-        'response': 'Response',
-        'custom_meta': 'XummCustomMeta'
+        'meta': dict,
+        'application': dict,
+        'payload': dict,
+        'response': dict,
+        'custom_meta': dict
     }
 
     attribute_map = {
@@ -1322,6 +1375,7 @@ class XummGetPayloadResponse(XummResource):
         :return: The XummGetPayloadResponse of this XummGetPayloadResponse.  # noqa: E501
         :rtype: XummGetPayloadResponse
         """
+        cls.sanity_check(kwargs)
         cls._meta = None
         cls._application = None
         cls._payload = None
@@ -1337,7 +1391,7 @@ class XummGetPayloadResponse(XummResource):
         """Returns the model properties as a dict"""
         result = {}
 
-        for attr, _ in six.iteritems(cls.model_types):
+        for attr, _ in six.iteritems(cls.attribute_map):
             value = getattr(cls, attr)
             attr = cls.attribute_map[attr]
             if isinstance(value, list):
@@ -1493,10 +1547,16 @@ class XummDeletePayloadResponse(XummResource):
       attribute_map (dict): The key is attribute name
                             and the value is json key in definition.
     """
+    required = {
+        'result': True,
+        'meta': True,
+        'custom_meta': True
+    }
+
     model_types = {
-        'result': 'Result',
-        'meta': 'Meta',
-        'custom_meta': 'XummCustomMeta'
+        'result': dict,
+        'meta': dict,
+        'custom_meta': dict
     }
 
     attribute_map = {
@@ -1514,6 +1574,7 @@ class XummDeletePayloadResponse(XummResource):
         :return: The XummDeletePayloadResponse of this XummDeletePayloadResponse.  # noqa: E501
         :rtype: XummDeletePayloadResponse
         """
+        cls.sanity_check(kwargs)
         cls._result = None
         cls._meta = None
         cls._custom_meta = None


### PR DESCRIPTION
Perform a type check on the model. 

We do this by adding the `required` and `nullable` fields on model.

We run the `sanity_check` at beginning of the `refresh_from` function.

So instead of the model type being `XyzModel` its `dict`. Then in the individual model you could check the type of str, or int.

I did this because python types are just helpers. They don't actually do anything unless I have been misinformed. But I double checked this in a type test. I tried to send the uuid as an int of 1 and it still allowed the model to be built and I thought that was wrong.

