### PR TITLE
update requests version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     packages=find_packages(include=('xumm*',)),
     include_package_data=True,
     install_requires=[
-        "requests==2.27.1",
+        "requests>=2.26.0",
         "websocket-client==1.2.3",
         "six==1.16.0",
         "python-dotenv==0.19.2"


### PR DESCRIPTION
Unless there is a great reason, like your implementation requires something that is only in 2.27.1 hard coding to only this version means builds will break with other dependent libraries in a project that may have not been updated to 2.27.1.

I used 2.26.0 here but really it should be the lowest compatible 2.xx version of requests.  